### PR TITLE
Fixes to input handling for bf programs

### DIFF
--- a/FunStuff/brainf.asm
+++ b/FunStuff/brainf.asm
@@ -297,7 +297,10 @@ _getch:
 .scope
 *	lda _py65_getc
 	beq -
-	rts
+	cmp #13		; convert CR to LF so as to be compliant on Windows
+	bne +
+	lda #10
+*	rts
 .scend
 
 _putch:

--- a/FunStuff/brainfdtc.asm
+++ b/FunStuff/brainfdtc.asm
@@ -398,7 +398,10 @@ _getch:
 .scope
 *	lda _py65_getc
 	beq -
-	rts
+	cmp #13		; convert CR to LF so as to be compliant on Windows
+	bne +
+	lda #10
+*	rts
 .scend
 
 _putch:

--- a/FunStuff/brainfitc.asm
+++ b/FunStuff/brainfitc.asm
@@ -376,7 +376,10 @@ _getch:
 .scope
 *	lda _py65_getc
 	beq -
-	rts
+	cmp #13		; convert CR to LF so as to be compliant on Windows
+	bne +
+	lda #10
+*	rts
 .scend
 
 _putch:

--- a/FunStuff/brainfitc.asm
+++ b/FunStuff/brainfitc.asm
@@ -190,7 +190,7 @@ _inputCell:
 	cmp #AscComma
 	bne _leftBracket
 
-	`emitCode incCell,inputCellEnd
+	`emitCode inputCell,inputCellEnd
 	jmp _next
 
 _leftBracket:

--- a/FunStuff/brainfo2tc.asm
+++ b/FunStuff/brainfo2tc.asm
@@ -719,7 +719,10 @@ _getch:
 .scope
 *	lda _py65_getc
 	beq -
-	rts
+	cmp #13		; convert CR to LF so as to be compliant on Windows
+	bne +
+	lda #10
+*	rts
 .scend
 
 _putch:

--- a/FunStuff/brainfo2tc.asm
+++ b/FunStuff/brainfo2tc.asm
@@ -262,7 +262,7 @@ _inputCell:
 	bne _leftBracket
 
 	jsr processState
-	`emitCode incCell,inputCellEnd
+	`emitCode inputCell,inputCellEnd
 	lda #0
 	sta cellCmpValid
 	jmp _next

--- a/FunStuff/brainfotc.asm
+++ b/FunStuff/brainfotc.asm
@@ -240,7 +240,7 @@ _inputCell:
 	cmp #AscComma
 	bne _leftBracket
 
-	`emitCode incCell,inputCellEnd
+	`emitCode inputCell,inputCellEnd
 	lda #StateDefault
 	sta state
 	jmp _next

--- a/FunStuff/brainfotc.asm
+++ b/FunStuff/brainfotc.asm
@@ -615,7 +615,10 @@ _getch:
 .scope
 *	lda _py65_getc
 	beq -
-	rts
+	cmp #13		; convert CR to LF so as to be compliant on Windows
+	bne +
+	lda #10
+*	rts
 .scend
 
 _putch:

--- a/FunStuff/brainfstc.asm
+++ b/FunStuff/brainfstc.asm
@@ -410,7 +410,10 @@ _getch:
 .scope
 *	lda _py65_getc
 	beq -
-	rts
+	cmp #13		; convert CR to LF so as to be compliant on Windows
+	bne +
+	lda #10
+*	rts
 .scend
 
 _putch:


### PR DESCRIPTION
This pull request fixes a couple of input-related issues:
- Fixes a bug in the new optimized bf implementations that affected input handling (typo caused wrong code to be generated for input to cell)
- Translate CR to LF on input so that interactive sample programs such as Conway's game of life will run. BF standard is for end of line input character is LF (10) however the emulator returns CR (13) when enter is pressed, at least when running on Windows.